### PR TITLE
progressively fallback on code retrieval options

### DIFF
--- a/genai/generate.py
+++ b/genai/generate.py
@@ -72,20 +72,29 @@ def generate_exception_suggestion(
     if len(error_report) > 1024:
         error_report = error_report[:1024] + "\n..."
 
-    messages = [
+    messages = []
+
+    messages.append(
         # Establish the context in which GPT will respond with role: assistant
         {
             "role": "system",
             "content": NOTEBOOK_ERROR_DIAGNOSER_PROCLAMATION,
         },
-        # The user sent code
-        {"role": "user", "content": code},
-        # The system literally wrote back with the error
+    )
+
+    if code is not None:
+        messages.append(
+            # The user sent code
+            {"role": "user", "content": code}
+        )
+
+    messages.append(
+        # The system wrote back with the error
         {
             "role": "system",
             "content": error_report,
         },
-    ]
+    )
 
     response = openai.ChatCompletion.create(
         model="gpt-3.5-turbo",

--- a/genai/suggestions.py
+++ b/genai/suggestions.py
@@ -50,8 +50,26 @@ def custom_exc(shell, etype, evalue, tb, tb_offset=None):
         return
 
     try:
-        # Get the current code
-        code = shell.user_ns["In"][-1]
+        code = None
+
+        execution_count = shell.execution_count
+
+        In = shell.user_ns["In"]
+        history_manager = shell.history_manager
+
+        # If the history is available, use that as it has the raw inputs (including magics)
+        if (history_manager is not None) and (
+            execution_count == len(history_manager.input_hist_raw) - 1
+        ):
+            code = shell.history_manager.input_hist_raw[execution_count]
+        # Fallback on In
+        elif In is not None and execution_count == len(In) - 1:
+            # Otherwise, use the current input buffer
+            code = In[execution_count]
+        # Otherwise history may not have been stored (store_history=False), so we should not send the
+        # code to GPT.
+        else:
+            code = None
 
         heading = display(Pretty(("Let's see how we can fix this... 🔧")), display_id=True)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,7 @@ ignore =
     D401
 max-line-length = 120
 max-complexity = 23
+extend-ignore = E203
 
 [bdist_wheel]
 universal=0

--- a/tests/test_suggestions.py
+++ b/tests/test_suggestions.py
@@ -3,6 +3,8 @@ from unittest import mock
 
 from genai import suggestions, generate
 
+from genai.suggestions import can_handle_display_updates
+
 
 def test_register():
     fake_ip = mock.MagicMock()
@@ -40,7 +42,85 @@ def test_custom_exc(create, publish_display_data, display, ip):
 
     ip.showtraceback = mock.MagicMock()
 
-    ip.user_ns["In"] = ["import pandas as pd", "fancy code"]
+    ip.execution_count = 2
+    ip.user_ns["In"] = None  # Ensure we use history_manager
+    ip.history_manager.input_hist_raw = ["", "import pandas as pd", "fancy code"]
+    print("history", ip.history_manager.input_hist_raw)
+
+    suggestions.custom_exc(ip, etype, evalue, tb, tb_offset=None)
+
+    # Ensure that we always report the users error back via the shell's showtraceback
+    ip.showtraceback.assert_called_once_with((etype, evalue, tb), tb_offset=None)
+
+    create.assert_called_once()
+
+    args, kwargs = create.call_args
+
+    assert args == ()
+    assert kwargs["model"] == "gpt-3.5-turbo"
+    assert len(kwargs["messages"]) == 3
+    assert kwargs["messages"][0] == {
+        "role": "system",
+        "content": generate.NOTEBOOK_ERROR_DIAGNOSER_PROCLAMATION,
+    }
+    assert kwargs["messages"][1] == {
+        "role": "user",
+        "content": "fancy code",
+    }
+    assert kwargs["messages"][2]["role"] == "system"
+    assert kwargs["messages"][2]["content"].startswith("Exception: this is just a test")
+
+    # display will be called *lots* of times
+    # For some reason this is only those that are using display IDs
+    display.assert_called()
+    # We also have to look at the publish_display_data calls
+    publish_display_data.assert_called()
+
+    last_call = display.call_args_list[-1]
+
+    # get kwargs from the last call
+    args = last_call[0]
+    kwargs = last_call[1]
+
+    # Now to check that we're publishing the correct data from the API
+    assert args[0] == {
+        "text/markdown": "## 💡 Suggestion\n\nHere's a suggestion",
+        "text/plain": "## 💡 Suggestion\n\nHere's a suggestion",
+    }
+
+
+@mock.patch(
+    "IPython.core.display_functions.display",
+    autospec=True,
+)
+@mock.patch(
+    "IPython.core.display_functions.publish_display_data",
+)
+@mock.patch(
+    "openai.ChatCompletion.create",
+    return_value={
+        "choices": [
+            {
+                "message": {
+                    "role": "assistant",
+                    "content": "Here's a suggestion",
+                },
+            },
+        ],
+    },
+    autospec=True,
+)
+def test_custom_exc_fallback_on_In(create, publish_display_data, display, ip):
+    try:
+        raise Exception("this is just a test")
+    except Exception:
+        (etype, evalue, tb) = sys.exc_info()
+
+    ip.showtraceback = mock.MagicMock()
+
+    ip.execution_count = 2
+    ip.user_ns["In"] = ["", "import pandas as pd", "fancy code"]
+    ip.history_manager.input_hist_raw = []
 
     suggestions.custom_exc(ip, etype, evalue, tb, tb_offset=None)
 
@@ -113,7 +193,11 @@ def test_custom_exc_long_traceback(create, publish_display_data, display, ip):
 
     ip.showtraceback = mock.MagicMock()
 
-    ip.user_ns["In"] = ["import pandas as pd", "fancy code"]
+    ip.execution_count = 2
+    print('execution_count!!!', ip.execution_count)
+    ip.user_ns["In"] = ["", "import pandas as pd", "fancy code"]
+    ip.history_manager.input_hist_raw = ["", "import pandas as pd", "fancy code"]
+    print("history", ip.history_manager.input_hist_raw)
 
     suggestions.custom_exc(ip, etype, evalue, tb, tb_offset=None)
 
@@ -163,6 +247,10 @@ def test_custom_exc_long_traceback(create, publish_display_data, display, ip):
     }
 
 
+@mock.patch(
+    "IPython.core.display_functions.display",
+    autospec=True,
+)
 @mock.patch("builtins.print")
 @mock.patch(
     "openai.ChatCompletion.create",
@@ -178,7 +266,7 @@ def test_custom_exc_long_traceback(create, publish_display_data, display, ip):
     },
     autospec=True,
 )
-def test_custom_exc_error_inside(create, print, ip):
+def test_custom_exc_error_inside(create, print, display, ip):
     ip.showtraceback = mock.MagicMock()
 
     try:
@@ -186,9 +274,8 @@ def test_custom_exc_error_inside(create, print, ip):
     except Exception:
         (etype, evalue, tb) = sys.exc_info()
 
-    # Force a TypeError in the suggestion code
-    # To make sure we exercise the fallback
-    ip.user_ns["In"] = None
+    # Force an error inside the custom_exc function
+    display.side_effect = TypeError("'Fun' is not allowed")
     suggestions.custom_exc(ip, etype, evalue, tb, tb_offset=None)
 
     # Ensure that we always report the users error back via the shell's showtraceback
@@ -196,4 +283,85 @@ def test_custom_exc_error_inside(create, print, ip):
 
     assert print.call_args.args[0] == "Error while trying to provide a suggestion: "
     assert print.call_args.args[1].__class__ == TypeError
-    assert print.call_args.args[1].args[0] == "'NoneType' object is not subscriptable"
+    assert print.call_args.args[1].args[0] == "'Fun' is not allowed"
+
+
+@mock.patch(
+    "IPython.core.display_functions.display",
+    autospec=True,
+)
+@mock.patch(
+    "IPython.core.display_functions.publish_display_data",
+)
+def test_pass_interrupts_through(publish_display_data, display, ip):
+    ip.showtraceback = mock.MagicMock()
+
+    try:
+        raise KeyboardInterrupt()
+    except KeyboardInterrupt:
+        (etype, evalue, tb) = sys.exc_info()
+
+    suggestions.custom_exc(ip, etype, evalue, tb, tb_offset=None)
+
+    # Ensure that we always report the users error back via the shell's showtraceback
+    ip.showtraceback.assert_called_once_with((etype, evalue, tb), tb_offset=None)
+
+    # display will be called *lots* of times
+    # For some reason this is only those that are using display IDs
+    display.assert_not_called()
+    # We also have to look at the publish_display_data calls
+    publish_display_data.assert_not_called()
+
+
+@mock.patch(
+    "IPython.core.display_functions.display",
+    autospec=True,
+)
+@mock.patch(
+    "IPython.core.display_functions.publish_display_data",
+)
+def test_pass_system_exit_through(publish_display_data, display, ip):
+    ip.showtraceback = mock.MagicMock()
+
+    try:
+        raise SystemExit()
+    except SystemExit:
+        (etype, evalue, tb) = sys.exc_info()
+
+    suggestions.custom_exc(ip, etype, evalue, tb, tb_offset=None)
+
+    # Ensure that we always report the users error back via the shell's showtraceback
+    ip.showtraceback.assert_called_once_with((etype, evalue, tb), tb_offset=None)
+
+    # display will be called *lots* of times
+    # For some reason this is only those that are using display IDs
+    display.assert_not_called()
+    # We also have to look at the publish_display_data calls
+    publish_display_data.assert_not_called()
+
+
+def fake_IPython(name):
+    '''Create a fake named IPython shell'''
+    return mock.MagicMock(
+        get_ipython=mock.Mock(return_value=mock.Mock(__class__=mock.Mock(__name__=name)))
+    )
+
+
+def test_can_handle_display_updates_with_ZMQInteractiveShell():
+    with mock.patch('builtins.__import__', return_value=fake_IPython("ZMQInteractiveShell")):
+        assert can_handle_display_updates() is True
+
+
+def test_can_handle_display_updates_with_TerminalInteractiveShell():
+    with mock.patch('builtins.__import__', return_value=fake_IPython("TerminalInteractiveShell")):
+        assert can_handle_display_updates() is False
+
+
+def test_no_IPython_means_no_display_updates():
+    with mock.patch('builtins.__import__', side_effect=ImportError()):
+        assert can_handle_display_updates() is False
+
+
+def test_can_handle_display_updates_with_other_shell():
+    with mock.patch('builtins.__import__', return_value=fake_IPython("SuperCoolInteractiveShell")):
+        assert can_handle_display_updates() is True


### PR DESCRIPTION
Closes #30 so that `%%bash` does not show up as `get_ipython().run_cell_magic('bash', '', '...')`.